### PR TITLE
Add alert display router

### DIFF
--- a/Sources/AnyTypes/AnyModalRouter.swift
+++ b/Sources/AnyTypes/AnyModalRouter.swift
@@ -60,6 +60,11 @@ private extension AnyModalRouter {
         get { presented?.transition == .popover ? presented : nil }
         set { presented = newValue }
     }
+
+    var alertRouter: AnyModalRouter? {
+        get { presented?.transition == .alert ? presented : nil }
+        set { presented = newValue }
+    }
 }
 
 public extension AnyModalRouter {
@@ -68,6 +73,7 @@ public extension AnyModalRouter {
         case sheet
         case fullScreen
         case popover
+        case alert
     }
 }
 
@@ -96,10 +102,24 @@ struct AnyModalView: View {
                         arrowEdge: .bottom, // TODO: - Pass from transition
                         content: { $0.makeView() }
                     )
+                    .alert(item: $router.alertRouter) { $0.makeAlert() }
             } else {
                 router.makeContentView()
             }
         }
         .onAppear { isReadyToPresent = true }
+    }
+}
+
+// MARK: - Default Alert Maker
+
+public extension AnyModalRouter {
+
+    /// Override in subclasses that support `.alert` transition to provide concrete SwiftUI `Alert` instance to display.
+    @MainActor
+    @inlinable
+    @available(*, renamed: "override makeAlert() in alert routers")
+    func makeAlert() -> Alert {
+        fatalError("[AnyModalRouter] makeAlert() should be overridden in subclasses when using `.alert` transition")
     }
 }

--- a/Sources/BaseTypes/AlertRouter.swift
+++ b/Sources/BaseTypes/AlertRouter.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Router that presents SwiftUI `Alert`s using `.alert` transition.
+open class AlertRouter: AnyModalRouter {
+
+    // MARK: Stored properties
+
+    /// Alert title text
+    public let title: LocalizedStringKey
+    /// Optional alert message text
+    public let message: LocalizedStringKey?
+    /// Primary `Alert.Button`
+    public let primaryButton: Alert.Button
+    /// Optional secondary `Alert.Button`. If `nil`, the alert will be created using the single-button initializer.
+    public let secondaryButton: Alert.Button?
+
+    // MARK: Initialization
+
+    public init(title: LocalizedStringKey,
+                message: LocalizedStringKey? = nil,
+                primaryButton: Alert.Button = .default(Text("OK")),
+                secondaryButton: Alert.Button? = nil,
+                presented: AnyModalRouter? = nil) {
+        self.title = title
+        self.message = message
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
+        super.init(transition: .alert, presented: presented)
+    }
+
+    // MARK: Overrides
+
+    /// Always returns an empty view because the actual UI is provided by `Alert`.
+    override func makeContentView() -> AnyView {
+        .init(EmptyView())
+    }
+
+    /// Creates the concrete `Alert` to present.
+    override func makeAlert() -> Alert {
+        if let secondaryButton {
+            return Alert(title: Text(title),
+                         message: message.map { Text($0) },
+                         primaryButton: primaryButton,
+                         secondaryButton: secondaryButton)
+        } else {
+            return Alert(title: Text(title),
+                         message: message.map { Text($0) },
+                         dismissButton: primaryButton)
+        }
+    }
+}


### PR DESCRIPTION
Add `AlertRouter` to allow presenting SwiftUI alerts via `AnyModalRouter`.

The existing `AnyModalRouter` system is extended with a new `.alert` transition type. A new `AlertRouter` subclass is introduced to specifically handle the creation and presentation of SwiftUI `Alert` instances, integrating them seamlessly into the modal presentation flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-faa2f5b0-ea90-4728-ae18-2164a3d8fc59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-faa2f5b0-ea90-4728-ae18-2164a3d8fc59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

