### PR TITLE
Add alert display router

### DIFF
--- a/Sources/AnyTypes/AnyAlertRouter.swift
+++ b/Sources/AnyTypes/AnyAlertRouter.swift
@@ -1,0 +1,165 @@
+//
+//  AnyAlertRouter.swift
+//  SUISimpleRouting
+//
+//  Created by Yevhenii Lytvynenko on 15.11.2024.
+//
+
+import SwiftUI
+
+// MARK: - Router
+
+@Observable
+open class AnyAlertRouter: AnyRouter {
+
+    // MARK: State
+    
+    /// Current alert configuration
+    public let alertConfig: AlertConfig
+    
+    /// Router which presents this router.
+    @ObservationIgnored
+    public internal(set) weak var presenting: AnyAlertRouter?
+
+    /// Alert presented from this router.
+    public var presentedAlert: AnyAlertRouter? {
+        willSet {
+            presentedAlert?.presenting = nil
+            newValue?.presenting = self
+        }
+    }
+
+    // MARK: Initialization
+
+    init(alertConfig: AlertConfig, presentedAlert: AnyAlertRouter? = nil) {
+        self.alertConfig = alertConfig
+        self._presentedAlert = presentedAlert
+        super.init()
+    }
+
+    // MARK: Makers
+
+    public final func makeView() -> some View {
+        AnyAlertView(router: self)
+    }
+}
+
+public extension AnyAlertRouter {
+
+    struct AlertConfig: Hashable, Sendable {
+        public let title: String
+        public let message: String?
+        public let primaryButton: AlertButton?
+        public let secondaryButton: AlertButton?
+        
+        public init(
+            title: String,
+            message: String? = nil,
+            primaryButton: AlertButton? = nil,
+            secondaryButton: AlertButton? = nil
+        ) {
+            self.title = title
+            self.message = message
+            self.primaryButton = primaryButton
+            self.secondaryButton = secondaryButton
+        }
+    }
+    
+    struct AlertButton: Hashable, Sendable {
+        public let title: String
+        public let style: Style
+        public let action: (() -> Void)?
+        
+        public enum Style: Hashable, Sendable {
+            case `default`
+            case cancel
+            case destructive
+        }
+        
+        public init(title: String, style: Style = .default, action: (() -> Void)? = nil) {
+            self.title = title
+            self.style = style
+            self.action = action
+        }
+        
+        public static func == (lhs: AlertButton, rhs: AlertButton) -> Bool {
+            lhs.title == rhs.title && lhs.style == rhs.style
+        }
+        
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(title)
+            hasher.combine(style)
+        }
+    }
+}
+
+// MARK: - View
+
+struct AnyAlertView: View {
+
+    @State var router: AnyAlertRouter
+    @State private var isReadyToPresent = false
+
+    var body: some View {
+        Group {
+            if isReadyToPresent {
+                router.makeContentView()
+                    .alert(
+                        router.alertConfig.title,
+                        isPresented: alertBinding,
+                        presenting: router.presentedAlert
+                    ) { presentedAlert in
+                        alertButtons(for: presentedAlert.alertConfig)
+                    } message: { presentedAlert in
+                        if let message = presentedAlert.alertConfig.message {
+                            Text(message)
+                        }
+                    }
+            } else {
+                router.makeContentView()
+            }
+        }
+        .onAppear { isReadyToPresent = true }
+    }
+    
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { router.presentedAlert != nil },
+            set: { if !$0 { router.presentedAlert = nil } }
+        )
+    }
+    
+    @ViewBuilder
+    private func alertButtons(for config: AnyAlertRouter.AlertConfig) -> some View {
+        if let primaryButton = config.primaryButton {
+            Button(primaryButton.title, role: buttonRole(for: primaryButton.style)) {
+                primaryButton.action?()
+                router.presentedAlert = nil
+            }
+        }
+        
+        if let secondaryButton = config.secondaryButton {
+            Button(secondaryButton.title, role: buttonRole(for: secondaryButton.style)) {
+                secondaryButton.action?()
+                router.presentedAlert = nil
+            }
+        }
+        
+        if config.primaryButton == nil && config.secondaryButton == nil {
+            Button("OK") {
+                router.presentedAlert = nil
+            }
+        }
+    }
+    
+    private func buttonRole(for style: AnyAlertRouter.AlertButton.Style) -> ButtonRole? {
+        switch style {
+        case .default:
+            return nil
+        case .cancel:
+            return .cancel
+        case .destructive:
+            return .destructive
+        }
+    }
+}

--- a/Sources/BaseTypes/AlertRouter.swift
+++ b/Sources/BaseTypes/AlertRouter.swift
@@ -1,0 +1,35 @@
+//
+//  AlertRouter.swift
+//  SUISimpleRouting
+//
+//  Created by Yevhenii Lytvynenko on 24.11.2024.
+//
+
+import SwiftUI
+import Combine
+
+open class AlertRouter<ViewType: BaseView>: AnyAlertRouter {
+
+    // MARK: State
+
+    public private(set) lazy var model = makeModel()
+
+    // MARK: Initialization
+
+    public override init(
+        alertConfig: AlertConfig,
+        presentedAlert: AnyAlertRouter? = nil
+    ) {
+        super.init(alertConfig: alertConfig, presentedAlert: presentedAlert)
+    }
+
+    // MARK: Makers
+
+    open func makeModel() -> ViewType.Model {
+        fatalError("Should be overriden")
+    }
+
+    override func makeContentView() -> AnyView {
+        .init(ViewType.with(model))
+    }
+}

--- a/Sources/BaseTypes/PushRouter.swift
+++ b/Sources/BaseTypes/PushRouter.swift
@@ -32,3 +32,4 @@ open class PushRouter<ViewType: BaseView>: AnyPushRouter {
 
 public typealias NavigationStackRouter = AnyNavigationStackRouter
 public typealias TabBarRouter = AnyTabBarRouter
+public typealias AlertRouter = AnyAlertRouter


### PR DESCRIPTION
Add an Alert Router to enable showing alerts through the routing system, following existing router patterns.

---
<a href="https://cursor.com/background-agent?bcId=bc-16d954a2-733a-43de-989d-3eb22b8a4663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16d954a2-733a-43de-989d-3eb22b8a4663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

