### PR TITLE
Add alert display router

### DIFF
--- a/Sources/AnyTypes/AnyAlertRouter.swift
+++ b/Sources/AnyTypes/AnyAlertRouter.swift
@@ -1,0 +1,98 @@
+//
+//  AnyAlertRouter.swift
+//  SUISimpleRouting
+//
+//  Created by Background Agent on 14.09.2025.
+//
+
+import SwiftUI
+
+// MARK: - Router
+
+@Observable
+open class AnyAlertRouter: AnyModalRouter {
+
+    public struct AlertState: Identifiable {
+        public enum Buttons {
+            case dismiss(Alert.Button)
+            case two(Alert.Button, Alert.Button)
+        }
+
+        public let id: String = UUID().uuidString
+        public var title: LocalizedStringKey
+        public var message: LocalizedStringKey?
+        public var buttons: Buttons
+
+        public init(
+            title: LocalizedStringKey,
+            message: LocalizedStringKey? = nil,
+            buttons: Buttons
+        ) {
+            self.title = title
+            self.message = message
+            self.buttons = buttons
+        }
+    }
+
+    /// Wrapped modal router which content will be displayed under the alert.
+    public var current: AnyModalRouter {
+        willSet {
+            current.presenting = nil
+            newValue.presenting = self
+        }
+    }
+
+    /// Forward presented router to the current one
+    public override var presented: AnyModalRouter? {
+        get { current.presented }
+        set { current.presented = newValue }
+    }
+
+    /// Alert presentation state
+    public var alert: AlertState?
+
+    public init(current: AnyModalRouter, transition: Transition) {
+        self.current = current
+        super.init(transition: transition)
+    }
+
+    override func makeContentView() -> AnyView {
+        .init(AnyAlertView(router: self))
+    }
+
+    // MARK: Convenience
+
+    public func showDismissAlert(
+        title: LocalizedStringKey,
+        message: LocalizedStringKey? = nil,
+        dismissTitle: LocalizedStringKey = "OK"
+    ) {
+        alert = .init(
+            title: title,
+            message: message,
+            buttons: .dismiss(.default(Text(dismissTitle)))
+        )
+    }
+}
+
+// MARK: - View
+
+private struct AnyAlertView: View {
+
+    @State var router: AnyAlertRouter
+
+    var body: some View {
+        router.current.makeView()
+            .alert(item: $router.alert) { state in
+                let title = Text(state.title)
+                let message = state.message.map(Text.init)
+                switch state.buttons {
+                case .dismiss(let button):
+                    return Alert(title: title, message: message, dismissButton: button)
+                case .two(let primary, let secondary):
+                    return Alert(title: title, message: message, primaryButton: primary, secondaryButton: secondary)
+                }
+            }
+    }
+}
+

--- a/Sources/BaseTypes/PushRouter.swift
+++ b/Sources/BaseTypes/PushRouter.swift
@@ -32,3 +32,4 @@ open class PushRouter<ViewType: BaseView>: AnyPushRouter {
 
 public typealias NavigationStackRouter = AnyNavigationStackRouter
 public typealias TabBarRouter = AnyTabBarRouter
+public typealias AlertRouter = AnyAlertRouter


### PR DESCRIPTION
Add `AnyAlertRouter` and `AlertRouter` typealias to enable routing and presentation of SwiftUI alerts.

This new router wraps an existing `AnyModalRouter` and applies a SwiftUI `.alert` modifier to its content, allowing for programmatic alert presentations.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f992cfe-d4f8-49b9-b3da-b4e0cd3ea09d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f992cfe-d4f8-49b9-b3da-b4e0cd3ea09d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

